### PR TITLE
Jan/large search batching

### DIFF
--- a/.github/workflows/tantivy-jpc.yml
+++ b/.github/workflows/tantivy-jpc.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
           delete-branch: true
           base: master
   build-mac:
-    runs-on: macos-11
+    runs-on: macos-13
 
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
           base: master
 
   build-mac-arm:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/.github/workflows/tantivy-jpc.yml
+++ b/.github/workflows/tantivy-jpc.yml
@@ -11,23 +11,24 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
 
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
-          default: true
-          override: true
       - name: Build
         run: cargo build --release && mv target/release/libtantivy_jpc.a go-client/tantivy/packaged/lib/linux-amd64/ && cp -u target/tantivy-jpc.h go-client/tantivy/packaged/include/
       - name: Run tests
         run: cargo test --verbose
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: update linux binary
           title: Update libtantivy_jpc.a
@@ -35,51 +36,22 @@ jobs:
           branch: update-linux-binary
           delete-branch: true
           base: master
-  build-mac:
-    runs-on: macos-13
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: x86_64-apple-darwin
-          default: true
-          override: true
-
-      - name: Build for mac
-        run: cargo build --release && mv target/release/libtantivy_jpc.a go-client/tantivy/packaged/lib/darwin-amd64/
-
-      - name: Run tests
-        run: cargo test --verbose
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          commit-message: update darwin lib
-          title: Update libtantivy_jpc.a
-          body: Credit new contributors by updating libtantivy_jpc.a
-          branch: update-darwin-lib
-          delete-branch: true
-          base: master
-
   build-mac-arm:
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: macos-14
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
-          target: aarch64-apple-darwin
-          default: true
-          override: true
+          targets: aarch64-apple-darwin
 
       - name: Build for mac
         run: cargo build --release --target aarch64-apple-darwin && mv target/aarch64-apple-darwin/release/libtantivy_jpc.a go-client/tantivy/packaged/lib/darwin-aarch64/
@@ -88,7 +60,7 @@ jobs:
         run: cargo test --verbose
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: update darwin aarch lib
           title: Update libtantivy_jpc.a

--- a/README.md
+++ b/README.md
@@ -171,3 +171,52 @@ func main() {
 ```
 
 ```
+
+## Choosing a Search Path
+
+Use `Search()` when the result set is modest and you want Tantivy to return the full stored document payload in one response.
+
+Use `SearchWithOptions()` when the match set still fits in one response but the caller only needs a subset of fields. Passing `SelectFields` cuts the JSON payload substantially and is the fastest option when a single response is still safe.
+
+Use `DocsetAll()` plus `GetDocumentsWithOptions()` when the caller must see the full match set before its own filtering or pagination, but should only hydrate selected fields. This is a good fit for vector-index sync and permission-filtering flows.
+
+Use `SearchWithOptionsBatched()` when the result set is too large to safely move across the Go/Rust boundary in one payload. It fetches all matching document references first, then hydrates selected fields in bounded batches and returns a single aggregated JSON array to the caller.
+
+Typical vector-sync pattern:
+
+```go
+docsetJSON, err := searcher.DocsetAll(true, 0)
+if err != nil {
+    panic(err)
+}
+
+var refs struct {
+    Docset []tantivy.SearchResultRef `json:"docset"`
+}
+if err := json.Unmarshal([]byte(docsetJSON), &refs); err != nil {
+    panic(err)
+}
+
+docsJSON, err := searcher.GetDocumentsWithOptions(refs.Docset, tantivy.GetDocumentsOptions{
+    SelectFields: []string{"title", "order"},
+})
+if err != nil {
+    panic(err)
+}
+
+_ = docsJSON
+```
+
+If you do not need explicit control over batching, the equivalent one-call helper is:
+
+```go
+docsJSON, err := searcher.SearchWithOptionsBatched(tantivy.SearchOptions{
+    Ordered:      true,
+    SelectFields: []string{"title", "order"},
+}, 256)
+if err != nil {
+    panic(err)
+}
+
+_ = docsJSON
+```

--- a/go-client/examples/main.go
+++ b/go-client/examples/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/JanFalkin/tantivy-jpc/go-client/tantivy"
 )
@@ -18,8 +20,13 @@ limbs and branches that arch over the pool`
 const oldMan = "He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish."
 
 func doRun() {
-	tantivy.LibInit("debug")
-	builder, err := tantivy.NewBuilder("")
+	tantivy.LibInit("info")
+	tmpDir, err := os.MkdirTemp("", "tantivy-vector-sync*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	builder, err := tantivy.NewBuilder(tmpDir)
 	if err != nil {
 		panic(err)
 	}
@@ -27,7 +34,7 @@ func doRun() {
 	if err != nil {
 		panic(err)
 	}
-	idxFieldBody, err := builder.AddTextField("body", tantivy.TEXT, false, true, "", false)
+	idxFieldBody, err := builder.AddTextField("body", tantivy.TEXT, true, true, "", false)
 	if err != nil {
 		panic(err)
 	}
@@ -41,20 +48,24 @@ func doRun() {
 	if err != nil {
 		panic(err)
 	}
-	doc1, err := doc.Create()
-	if err != nil {
-		panic(err)
+	bodySeed := strings.Repeat(ofMiceAndMen+" ", 24)
+	for i := 0; i < 12; i++ {
+		docID, err := doc.Create()
+		if err != nil {
+			panic(err)
+		}
+		title := fmt.Sprintf("Vector Candidate %02d", i)
+		body := fmt.Sprintf("vector-sync-%02d %s %s", i, oldMan, bodySeed)
+		if _, err = doc.AddText(idxFieldTitle, title, docID); err != nil {
+			panic(err)
+		}
+		if _, err = doc.AddText(idxFieldBody, body, docID); err != nil {
+			panic(err)
+		}
+		if _, err = doc.AddInt(idxFieldOrder, int64(1000+i), docID); err != nil {
+			panic(err)
+		}
 	}
-	doc2, err := doc.Create()
-	if err != nil {
-		panic(err)
-	}
-	doc.AddText(idxFieldTitle, "The Old Man and the Sea", doc1)
-	doc.AddText(idxFieldBody, oldMan, doc1)
-	doc.AddInt(idxFieldOrder, 111, doc1)
-	doc.AddText(idxFieldTitle, "Of Mice and Men", doc2)
-	doc.AddText(idxFieldBody, ofMiceAndMen, doc2)
-	doc.AddInt(idxFieldOrder, 222, doc2)
 
 	idx, err := doc.CreateIndex()
 	if err != nil {
@@ -69,13 +80,10 @@ func doRun() {
 	if err != nil {
 		panic(err)
 	}
-	_, err = idw.AddDocument(doc1)
-	if err != nil {
-		panic(err)
-	}
-	_, err = idw.AddDocument(doc2)
-	if err != nil {
-		panic(err)
+	for docID := uint(1); docID <= 12; docID++ {
+		if _, err = idw.AddDocument(docID); err != nil {
+			panic(err)
+		}
 	}
 
 	_, err = idw.Commit()
@@ -93,52 +101,54 @@ func doRun() {
 		panic(err)
 	}
 
-	_, err = qp.ForIndex([]string{"title", "body"})
+	_, err = qp.ForIndex([]string{"title", "body", "order"})
 	if err != nil {
 		panic(err)
 	}
 
-	searcher, err := qp.ParseQuery("order:111")
+	searcher, err := qp.ParseQuery("body:vector-sync")
+	if err != nil {
+		panic(err)
+	}
+	docsetJSON, err := searcher.DocsetAll(true, 0)
+	if err != nil {
+		panic(err)
+	}
+	var refs struct {
+		Docset []tantivy.SearchResultRef `json:"docset"`
+	}
+	if err = json.Unmarshal([]byte(docsetJSON), &refs); err != nil {
+		panic(err)
+	}
+
+	vectorSyncJSON, err := searcher.GetDocumentsWithOptions(refs.Docset, tantivy.GetDocumentsOptions{
+		SelectFields: []string{"title", "order"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	batchedJSON, err := searcher.SearchWithOptionsBatched(tantivy.SearchOptions{
+		Ordered:      true,
+		SelectFields: []string{"title", "order"},
+	}, 4)
 	if err != nil {
 		panic(err)
 	}
 
-	var sr []map[string]interface{}
-
-	s, err := searcher.Search(false, 0, 0, true)
-	if err != nil {
+	var projected []map[string]interface{}
+	if err = json.Unmarshal([]byte(vectorSyncJSON), &projected); err != nil {
+		panic(err)
+	}
+	var batched []map[string]interface{}
+	if err = json.Unmarshal([]byte(batchedJSON), &batched); err != nil {
 		panic(err)
 	}
 
-	err = json.Unmarshal([]byte(s), &sr)
-	if err != nil {
-		panic(err)
-	}
-	if sr[0]["doc"].(map[string]interface{})["title"].([]interface{})[0] != "The Old Man and the Sea" {
-		panic("expected value not received")
-	}
-	if err != nil {
-		panic(err)
-	}
-	searcherAgain, err := qp.ParseQuery("order:222")
-	if err != nil {
-		panic(err)
-	}
-	s, err = searcherAgain.Search(false, 0, 0, true)
-	if err != nil {
-		panic(err)
-	}
-	err = json.Unmarshal([]byte(s), &sr)
-	if err != nil {
-		panic(err)
-	}
-
-	if sr[0]["doc"].(map[string]interface{})["title"].([]interface{})[0] != "Of Mice and Men" {
-		panic("expected value not received")
-	}
+	fmt.Printf("vector-sync refs=%d hydrated=%d direct-bytes=%d batched-bytes=%d\n", len(refs.Docset), len(projected), len(vectorSyncJSON), len(batchedJSON))
+	fmt.Printf("first hydrated doc: %s\n", projected[0]["doc"].(map[string]interface{})["title"].([]interface{})[0])
 
 	tantivy.ClearSession(builder.ID())
-	fmt.Println("It worked!!!")
+	fmt.Println("vector sync demo complete")
 
 }
 

--- a/go-client/tantivy/tantivy.go
+++ b/go-client/tantivy/tantivy.go
@@ -12,6 +12,8 @@ package tantivy
 import "C"
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"os"
 	"sync"
 	"unsafe"
@@ -58,6 +60,19 @@ func (j *JPCId) ID() string {
 	return j.id
 }
 
+func readResponseBuffer(ptr *C.uchar, length C.uintptr_t) ([]byte, error) {
+	if ptr == nil {
+		if length == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("tantivy_jpc returned a nil buffer with length %d", uint64(length))
+	}
+	if uint64(length) > uint64(math.MaxInt32) {
+		return nil, fmt.Errorf("tantivy_jpc returned %d bytes, exceeding the Go cgo byte limit", uint64(length))
+	}
+	return C.GoBytes(unsafe.Pointer(ptr), C.int(length)), nil
+}
+
 func (jpc *JPCId) callTantivy(object, method string, params msi) (string, error) {
 	f := map[string]interface{}{
 		"id":     jpc.id,
@@ -70,22 +85,26 @@ func (jpc *JPCId) callTantivy(object, method string, params msi) (string, error)
 	if err != nil {
 		return "", err
 	}
-	var pcomsBuf *C.char
-	var blen int64
 	sb := string(b)
 	pcJPCParams := C.CString(sb)
-	pCDesctination := (*C.uchar)(unsafe.Pointer(pcomsBuf))
+	defer C.free(unsafe.Pointer(pcJPCParams))
+	var pCDesctination *C.uchar
+	var blen C.uintptr_t
 	cJPCParams := (*C.uchar)(unsafe.Pointer(pcJPCParams))
-	pDestinationLen := (*C.ulong)(unsafe.Pointer(&blen))
-	ttret := C.tantivy_jpc(cJPCParams, C.ulong(uint64(len(sb))), &pCDesctination, pDestinationLen)
-	if ttret < 0 {
-		return "", errors.E("Tantivy JPC Failed", errors.K.Invalid, "desc", string(C.GoBytes(unsafe.Pointer(pCDesctination), C.int(*pDestinationLen))))
+	ttret := C.tantivy_jpc(cJPCParams, C.uintptr_t(len(sb)), &pCDesctination, &blen)
+	if ttret >= 0 {
+		defer C.free_data(ttret)
 	}
-	defer func() {
-		if ttret >= 0 {
-			C.free_data(ttret)
+	returnBytes, readErr := readResponseBuffer(pCDesctination, blen)
+	if ttret < 0 {
+		if readErr != nil {
+			return "", errors.E("Tantivy JPC Failed", errors.K.Invalid, "desc", readErr.Error())
 		}
-	}()
-	returnData := string(C.GoBytes(unsafe.Pointer(pCDesctination), C.int(*pDestinationLen)))
+		return "", errors.E("Tantivy JPC Failed", errors.K.Invalid, "desc", string(returnBytes))
+	}
+	if readErr != nil {
+		return "", errors.E("Tantivy JPC Failed", errors.K.Invalid, "desc", readErr.Error())
+	}
+	returnData := string(returnBytes)
 	return returnData, nil
 }

--- a/go-client/tantivy/tantivy_searcher.go
+++ b/go-client/tantivy/tantivy_searcher.go
@@ -1,10 +1,50 @@
 package tantivy
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
 type TSearcher struct {
 	*TQueryParser
 }
 
 const NOSNIPPET = -1
+
+type SearchOptions struct {
+	Explain       bool
+	TopLimit      uint64
+	Offset        uint64
+	Ordered       bool
+	SnippetFields []string
+	SelectFields  []string
+}
+
+type GetDocumentOptions struct {
+	Explain       bool
+	Score         float32
+	DocID         uint32
+	SegmentOrd    uint32
+	SnippetFields []string
+	SelectFields  []string
+}
+
+type GetDocumentsOptions struct {
+	Explain       bool
+	SnippetFields []string
+	SelectFields  []string
+}
+
+type SearchResultRef struct {
+	Score      float32 `json:"score"`
+	SegmentOrd uint32  `json:"segment_ord"`
+	DocID      uint32  `json:"doc_id"`
+}
+
+type docsetEnvelope struct {
+	Docset []SearchResultRef `json:"docset"`
+}
 
 func (s *TSearcher) Docset(scoring bool, topLimit uint64, offset uint64) (string, error) {
 	return s.callTantivy("searcher", "docset", msi{
@@ -14,29 +54,125 @@ func (s *TSearcher) Docset(scoring bool, topLimit uint64, offset uint64) (string
 	})
 }
 
+func (s *TSearcher) DocsetAll(scoring bool, offset uint64) (string, error) {
+	return s.callTantivy("searcher", "docset", msi{
+		"top_limit": uint64(0),
+		"offset":    offset,
+		"scoring":   scoring,
+	})
+}
+
 func (s *TSearcher) GetDocument(explain bool, score float32, docId uint32, segOrd uint32, snippetField ...string) (string, error) {
-	return s.callTantivy("searcher", "get_document", msi{
-		"segment_ord":   segOrd,
-		"doc_id":        docId,
-		"score":         score,
-		"explain":       explain,
-		"snippet_field": snippetField,
+	return s.GetDocumentWithOptions(GetDocumentOptions{
+		Explain:       explain,
+		Score:         score,
+		DocID:         docId,
+		SegmentOrd:    segOrd,
+		SnippetFields: snippetField,
 	})
 }
 
 func (s *TSearcher) Search(explain bool, topLimit uint64, offset uint64, ordered bool, snippetField ...string) (string, error) {
-	args := msi{"scoring": ordered, "offset": offset, "snippet_field": snippetField}
-	if topLimit >= 1 {
-		args["top_limit"] = topLimit
+	return s.SearchWithOptions(SearchOptions{
+		Explain:       explain,
+		TopLimit:      topLimit,
+		Offset:        offset,
+		Ordered:       ordered,
+		SnippetFields: snippetField,
+	})
+}
+
+func (s *TSearcher) SearchWithOptions(options SearchOptions) (string, error) {
+	args := msi{
+		"scoring": options.Ordered,
+		"offset":  options.Offset,
 	}
-	if explain {
+	if len(options.SnippetFields) > 0 {
+		args["snippet_field"] = options.SnippetFields
+	}
+	if len(options.SelectFields) > 0 {
+		args["select_fields"] = options.SelectFields
+	}
+	if options.TopLimit >= 1 {
+		args["top_limit"] = options.TopLimit
+	}
+	if options.Explain {
 		args["explain"] = true
 	}
 	return s.callTantivy("searcher", "search", args)
 }
 
-func (s *TSearcher) SearchRaw() (string, error) {
+func (s *TSearcher) GetDocumentWithOptions(options GetDocumentOptions) (string, error) {
+	args := msi{
+		"segment_ord": options.SegmentOrd,
+		"doc_id":      options.DocID,
+		"score":       options.Score,
+		"explain":     options.Explain,
+	}
+	if len(options.SnippetFields) > 0 {
+		args["snippet_field"] = options.SnippetFields
+	}
+	if len(options.SelectFields) > 0 {
+		args["select_fields"] = options.SelectFields
+	}
+	return s.callTantivy("searcher", "get_document", args)
+}
+
+func (s *TSearcher) GetDocumentsWithOptions(docs []SearchResultRef, options GetDocumentsOptions) (string, error) {
+	args := msi{
+		"docs":    docs,
+		"explain": options.Explain,
+	}
+	if len(options.SnippetFields) > 0 {
+		args["snippet_field"] = options.SnippetFields
+	}
+	if len(options.SelectFields) > 0 {
+		args["select_fields"] = options.SelectFields
+	}
+	return s.callTantivy("searcher", "get_documents", args)
+}
+
+func (s *TSearcher) SearchWithOptionsBatched(options SearchOptions, batchSize uint64) (string, error) {
+	docsetResponse, err := s.docsetForOptions(options)
+	if err != nil {
+		return "", err
+	}
+	if len(docsetResponse.Docset) == 0 {
+		return "[]", nil
+	}
+	if batchSize == 0 {
+		batchSize = 256
+	}
+
+	var out bytes.Buffer
+	out.WriteByte('[')
+	first := true
+	for start := 0; start < len(docsetResponse.Docset); start += int(batchSize) {
+		end := start + int(batchSize)
+		if end > len(docsetResponse.Docset) {
+			end = len(docsetResponse.Docset)
+		}
+		batchJSON, err := s.GetDocumentsWithOptions(docsetResponse.Docset[start:end], GetDocumentsOptions{
+			Explain:       options.Explain,
+			SnippetFields: options.SnippetFields,
+			SelectFields:  options.SelectFields,
+		})
+		if err != nil {
+			return "", err
+		}
+		if err := appendJSONArray(&out, batchJSON, &first); err != nil {
+			return "", err
+		}
+	}
+	out.WriteByte(']')
+	return out.String(), nil
+}
+
+func (s *TSearcher) SearchRaw(limit ...uint64) (string, error) {
 	args := msi{}
+	if len(limit) >= 1 && limit[0] >= 1 {
+		args["limit"] = limit[0]
+	}
 	return s.callTantivy("searcher", "search_raw", args)
 }
 
@@ -46,4 +182,41 @@ func (s *TSearcher) FuzzySearch(topLimit ...uint64) (string, error) {
 		args["top_limit"] = topLimit[0]
 	}
 	return s.callTantivy("fuzzy_searcher", "fuzzy_searcher", msi{})
+}
+
+func (s *TSearcher) docsetForOptions(options SearchOptions) (*docsetEnvelope, error) {
+	args := msi{
+		"offset":  options.Offset,
+		"scoring": options.Ordered,
+	}
+	if options.TopLimit > 0 {
+		args["top_limit"] = options.TopLimit
+	} else {
+		args["top_limit"] = uint64(0)
+	}
+	docsetJSON, err := s.callTantivy("searcher", "docset", args)
+	if err != nil {
+		return nil, err
+	}
+	var envelope docsetEnvelope
+	if err := json.Unmarshal([]byte(docsetJSON), &envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode docset response: %w", err)
+	}
+	return &envelope, nil
+}
+
+func appendJSONArray(out *bytes.Buffer, arrayJSON string, first *bool) error {
+	var docs []json.RawMessage
+	if err := json.Unmarshal([]byte(arrayJSON), &docs); err != nil {
+		return fmt.Errorf("failed to decode batch documents: %w", err)
+	}
+	for _, doc := range docs {
+		if !*first {
+			out.WriteByte(',')
+		} else {
+			*first = false
+		}
+		out.Write(doc)
+	}
+	return nil
 }

--- a/go-client/tantivy/tantivy_test.go
+++ b/go-client/tantivy/tantivy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/eluv-io/log-go"
@@ -17,102 +18,104 @@ const resultSetNick = "[{\"doc\":{\"body\":[\"He was an old man who fished alone
 
 type jm = map[string]interface{}
 
-func makeFuzzyIndex(t *testing.T, td string, useExisting bool) *TIndex {
+func makeFuzzyIndex(tb testing.TB, td string, useExisting bool) *TIndex {
+	tb.Helper()
 	builder, err := NewBuilder(td)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	idxFieldTitle, err := builder.AddTextField("title", TEXT, true, true, "", false)
-	require.NoError(t, err)
-	require.EqualValues(t, 0, idxFieldTitle)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 0, idxFieldTitle)
 	idxFieldInt, err := builder.AddI64Field("test", INT, true, true, false)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, idxFieldInt)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 1, idxFieldInt)
 
 	doc, err := builder.Build()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	doc1, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, doc1)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 1, doc1)
 	doc2, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 2, doc2)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 2, doc2)
 	doc3, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 3, doc3)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 3, doc3)
 	doc4, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 4, doc4)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 4, doc4)
 
 	_, err = doc.AddText(idxFieldTitle, "The Name of the Wind", doc1)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 444, doc1)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldTitle, "The Diary of Muadib", doc2)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 555, doc2)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldTitle, "A Dairy Cow", doc3)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 666, doc3)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldTitle, "The Diary of a Young Girl", doc4)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 777, doc4)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	idx, err := doc.CreateIndex()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	if !useExisting {
 		idw, err := idx.CreateIndexWriter()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		opst1, err := idw.AddDocument(doc1)
-		require.NoError(t, err)
-		require.EqualValues(t, 0, opst1)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 0, opst1)
 		opst2, err := idw.AddDocument(doc2)
-		require.NoError(t, err)
-		require.EqualValues(t, 1, opst2)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 1, opst2)
 		opst3, err := idw.AddDocument(doc3)
-		require.NoError(t, err)
-		require.EqualValues(t, 2, opst3)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 2, opst3)
 		opst4, err := idw.AddDocument(doc4)
-		require.NoError(t, err)
-		require.EqualValues(t, 3, opst4)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 3, opst4)
 
 		fmt.Printf("op1 = %v op2 = %v op3 = %v op4 = %v\n ", opst1, opst2, opst3, opst4)
 		idCommit, err := idw.Commit()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		fmt.Printf("commit id = %v", idCommit)
 	}
 	return idx
 }
 
-func makeIndex(t *testing.T, td string, useExisting bool) *TIndex {
+func makeIndex(tb testing.TB, td string, useExisting bool) *TIndex {
+	tb.Helper()
 	builder, err := NewBuilder(td)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	idxFieldTitle, err := builder.AddTextField("title", TEXT, true, true, "", false)
-	require.NoError(t, err)
-	require.EqualValues(t, 0, idxFieldTitle)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 0, idxFieldTitle)
 	idxFieldBody, err := builder.AddTextField("body", TEXT, true, true, "", false)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, idxFieldBody)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 1, idxFieldBody)
 	idxFieldInt, err := builder.AddI64Field("test", INT, true, true, true)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, idxFieldInt)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 2, idxFieldInt)
 	doc, err := builder.Build()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	doc1, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, doc1)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 1, doc1)
 	doc2, err := doc.Create()
-	require.NoError(t, err)
-	require.EqualValues(t, 2, doc2)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 2, doc2)
 	_, err = doc.AddText(idxFieldTitle, "The Old Man and the Sea", doc1)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldBody, "He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish. The water was warm but fishless.", doc1)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 555, doc1)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldTitle, "Of Mice and Men", doc2)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddText(idxFieldBody, `A few miles south of Soledad, the Salinas River drops in close to the hillside
 	bank and runs deep and green. The water is warm too, for it has slipped twinkling
 	over the yellow sands in the sunlight before reaching the narrow pool. On one
@@ -121,26 +124,74 @@ func makeIndex(t *testing.T, td string, useExisting bool) *TIndex {
 	fresh and green with every spring, carrying in their lower leaf junctures the
 	debris of the winter's flooding; and sycamores with mottled, white, recumbent
 	limbs and branches that arch over the pool`, doc2)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	_, err = doc.AddInt(idxFieldInt, 666, doc2)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	idx, err := doc.CreateIndex()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	if !useExisting {
 		idw, err := idx.CreateIndexWriter()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		opst1, err := idw.AddDocument(doc1)
-		require.NoError(t, err)
-		require.EqualValues(t, 0, opst1)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 0, opst1)
 		opst2, err := idw.AddDocument(doc2)
-		require.NoError(t, err)
-		require.EqualValues(t, 1, opst2)
+		require.NoError(tb, err)
+		require.EqualValues(tb, 1, opst2)
 		fmt.Printf("op1 = %v op2 = %v\n", opst1, opst2)
 		idCommit, err := idw.Commit()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		fmt.Printf("commit id = %v", idCommit)
 	}
+	return idx
+}
+
+func makeLargeIndex(tb testing.TB, td string, docCount int, bodyRepeat int) *TIndex {
+	tb.Helper()
+	builder, err := NewBuilder(td)
+	require.NoError(tb, err)
+	idxFieldTitle, err := builder.AddTextField("title", TEXT, true, true, "", false)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 0, idxFieldTitle)
+	idxFieldBody, err := builder.AddTextField("body", TEXT, true, true, "", false)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 1, idxFieldBody)
+	idxFieldInt, err := builder.AddI64Field("test", INT, true, true, true)
+	require.NoError(tb, err)
+	require.EqualValues(tb, 2, idxFieldInt)
+
+	doc, err := builder.Build()
+	require.NoError(tb, err)
+
+	bodyChunk := strings.Repeat("payload token search demo chunk ", bodyRepeat)
+	docIDs := make([]uint, 0, docCount)
+	for i := 0; i < docCount; i++ {
+		docID, err := doc.Create()
+		require.NoError(tb, err)
+		docIDs = append(docIDs, docID)
+
+		title := fmt.Sprintf("Large Search Demo %03d", i)
+		body := fmt.Sprintf("doc-%03d %s tail-marker-%03d", i, bodyChunk, i)
+		_, err = doc.AddText(idxFieldTitle, title, docID)
+		require.NoError(tb, err)
+		_, err = doc.AddText(idxFieldBody, body, docID)
+		require.NoError(tb, err)
+		_, err = doc.AddInt(idxFieldInt, int64(1000+i), docID)
+		require.NoError(tb, err)
+	}
+
+	idx, err := doc.CreateIndex()
+	require.NoError(tb, err)
+	idw, err := idx.CreateIndexWriter()
+	require.NoError(tb, err)
+	for i, docID := range docIDs {
+		opstamp, err := idw.AddDocument(docID)
+		require.NoError(tb, err)
+		require.EqualValues(tb, i, opstamp)
+	}
+	_, err = idw.Commit()
+	require.NoError(tb, err)
 	return idx
 }
 
@@ -689,6 +740,296 @@ func TestDocsetSnippetSearch(t *testing.T) {
 	resDoc := results["doc"].(jm)
 	require.EqualValues(t, "Of Mice and Men", resDoc["title"].([]interface{})[0].(string))
 	require.EqualValues(t, "A few miles south of Soledad, the Salinas River drops in close to the hillside\n\tbank and runs deep and green. The water is warm too, for it has slipped <b>twinkling</b>\n\tover the yellow sands in the sunlight before reaching the narrow pool. On one\n\tside of the river the golden foothill slopes curve up to the strong and rocky\n\tGabilan Mountains, but on the valley side the water is lined with trees—willows\n\tfresh and green with every spring, carrying in their lower leaf junctures the\n\tdebris of the winter&#x27;s flooding; and sycamores with mottled, white, recumbent\n\tlimbs and branches that arch over the pool", results["snippet_html"].(jm)["body"])
+}
+
+func TestSearchSelectFields(t *testing.T) {
+	t.Setenv("LD_LIBRARY_PATH", ".")
+	LibInit()
+	td, err := ioutil.TempDir("", "tindex*")
+	defer func(err error) {
+		if err == nil {
+			if os.RemoveAll(td) != nil {
+				log.Error("unable to cleanup temp dir", "val", td)
+			}
+		}
+	}(err)
+	require.NoError(t, err)
+
+	idx := makeIndex(t, td, false)
+	rb, err := idx.ReaderBuilder()
+	require.NoError(t, err)
+	qp, err := rb.Searcher()
+	require.NoError(t, err)
+
+	_, err = qp.ForIndex([]string{"title", "body", "test"})
+	require.NoError(t, err)
+
+	searcher, err := qp.ParseQuery("title:Sea")
+	require.NoError(t, err)
+
+	s, err := searcher.SearchWithOptions(SearchOptions{
+		TopLimit:     1,
+		Ordered:      true,
+		SelectFields: []string{"title"},
+	})
+	require.NoError(t, err)
+
+	results := []map[string]interface{}{}
+	err = json.Unmarshal([]byte(s), &results)
+	require.NoError(t, err)
+	require.EqualValues(t, "The Old Man and the Sea", results[0]["doc"].(map[string]interface{})["title"].([]interface{})[0].(string))
+	_, hasBody := results[0]["doc"].(map[string]interface{})["body"]
+	require.False(t, hasBody)
+
+	docset, err := searcher.Docset(true, 1, 0)
+	require.NoError(t, err)
+	var docsetResults map[string]interface{}
+	err = json.Unmarshal([]byte(docset), &docsetResults)
+	require.NoError(t, err)
+	docRef := docsetResults["docset"].([]interface{})[0].(jm)
+
+	sDoc, err := searcher.GetDocumentWithOptions(GetDocumentOptions{
+		Score:        float32(docRef["score"].(float64)),
+		DocID:        uint32(docRef["doc_id"].(float64)),
+		SegmentOrd:   uint32(docRef["segment_ord"].(float64)),
+		SelectFields: []string{"title"},
+	})
+	require.NoError(t, err)
+
+	var documentResult map[string]interface{}
+	err = json.Unmarshal([]byte(sDoc), &documentResult)
+	require.NoError(t, err)
+	require.EqualValues(t, "The Old Man and the Sea", documentResult["doc"].(map[string]interface{})["title"].([]interface{})[0].(string))
+	_, hasDocumentBody := documentResult["doc"].(map[string]interface{})["body"]
+	require.False(t, hasDocumentBody)
+}
+
+func TestLargeSearchWithOptions(t *testing.T) {
+	t.Setenv("LD_LIBRARY_PATH", ".")
+	LibInit()
+	td, err := ioutil.TempDir("", "tindex-large*")
+	defer func(err error) {
+		if err == nil {
+			if os.RemoveAll(td) != nil {
+				log.Error("unable to cleanup temp dir", "val", td)
+			}
+		}
+	}(err)
+	require.NoError(t, err)
+
+	const docCount = 24
+	idx := makeLargeIndex(t, td, docCount, 180)
+	rb, err := idx.ReaderBuilder()
+	require.NoError(t, err)
+	qp, err := rb.Searcher()
+	require.NoError(t, err)
+
+	_, err = qp.ForIndex([]string{"title", "body", "test"})
+	require.NoError(t, err)
+
+	searcher, err := qp.ParseQuery("body:payload")
+	require.NoError(t, err)
+
+	fullResponse, err := searcher.Search(false, docCount, 0, true)
+	require.NoError(t, err)
+	projectedResponse, err := searcher.SearchWithOptions(SearchOptions{
+		TopLimit:     docCount,
+		Ordered:      true,
+		SelectFields: []string{"title", "test"},
+	})
+	require.NoError(t, err)
+
+	var fullResults []map[string]interface{}
+	err = json.Unmarshal([]byte(fullResponse), &fullResults)
+	require.NoError(t, err)
+	require.Len(t, fullResults, docCount)
+
+	var projectedResults []map[string]interface{}
+	err = json.Unmarshal([]byte(projectedResponse), &projectedResults)
+	require.NoError(t, err)
+	require.Len(t, projectedResults, docCount)
+
+	firstFullDoc := fullResults[0]["doc"].(map[string]interface{})
+	require.NotEmpty(t, firstFullDoc["body"].([]interface{})[0].(string))
+	for _, result := range projectedResults {
+		projectedDoc := result["doc"].(map[string]interface{})
+		_, hasProjectedBody := projectedDoc["body"]
+		require.False(t, hasProjectedBody)
+		require.True(t, strings.HasPrefix(projectedDoc["title"].([]interface{})[0].(string), "Large Search Demo "))
+		testValue := projectedDoc["test"].([]interface{})[0].(float64)
+		require.GreaterOrEqual(t, testValue, float64(1000))
+		require.Less(t, testValue, float64(1000+docCount))
+	}
+
+	fullLen := len(fullResponse)
+	projectedLen := len(projectedResponse)
+	require.Greater(t, fullLen, projectedLen)
+	require.GreaterOrEqual(t, fullLen/projectedLen, 8)
+}
+
+func TestLargeDocsetAllGetDocumentsWithOptions(t *testing.T) {
+	t.Setenv("LD_LIBRARY_PATH", ".")
+	LibInit()
+	td, err := ioutil.TempDir("", "tindex-docset-large*")
+	defer func(err error) {
+		if err == nil {
+			if os.RemoveAll(td) != nil {
+				log.Error("unable to cleanup temp dir", "val", td)
+			}
+		}
+	}(err)
+	require.NoError(t, err)
+
+	const docCount = 24
+	idx := makeLargeIndex(t, td, docCount, 180)
+	rb, err := idx.ReaderBuilder()
+	require.NoError(t, err)
+	qp, err := rb.Searcher()
+	require.NoError(t, err)
+
+	_, err = qp.ForIndex([]string{"title", "body", "test"})
+	require.NoError(t, err)
+
+	searcher, err := qp.ParseQuery("body:payload")
+	require.NoError(t, err)
+
+	docsetJSON, err := searcher.DocsetAll(true, 0)
+	require.NoError(t, err)
+	var docset docsetEnvelope
+	err = json.Unmarshal([]byte(docsetJSON), &docset)
+	require.NoError(t, err)
+	require.Len(t, docset.Docset, docCount)
+
+	documentsJSON, err := searcher.GetDocumentsWithOptions(docset.Docset, GetDocumentsOptions{
+		SelectFields: []string{"title", "test"},
+	})
+	require.NoError(t, err)
+
+	var documents []map[string]interface{}
+	err = json.Unmarshal([]byte(documentsJSON), &documents)
+	require.NoError(t, err)
+	require.Len(t, documents, docCount)
+	for _, document := range documents {
+		doc := document["doc"].(map[string]interface{})
+		_, hasBody := doc["body"]
+		require.False(t, hasBody)
+		require.True(t, strings.HasPrefix(doc["title"].([]interface{})[0].(string), "Large Search Demo "))
+	}
+}
+
+func TestLargeSearchWithOptionsBatched(t *testing.T) {
+	t.Setenv("LD_LIBRARY_PATH", ".")
+	LibInit()
+	td, err := ioutil.TempDir("", "tindex-batched-large*")
+	defer func(err error) {
+		if err == nil {
+			if os.RemoveAll(td) != nil {
+				log.Error("unable to cleanup temp dir", "val", td)
+			}
+		}
+	}(err)
+	require.NoError(t, err)
+
+	const docCount = 24
+	idx := makeLargeIndex(t, td, docCount, 180)
+	rb, err := idx.ReaderBuilder()
+	require.NoError(t, err)
+	qp, err := rb.Searcher()
+	require.NoError(t, err)
+
+	_, err = qp.ForIndex([]string{"title", "body", "test"})
+	require.NoError(t, err)
+
+	searcher, err := qp.ParseQuery("body:payload")
+	require.NoError(t, err)
+
+	fullResponse, err := searcher.Search(false, docCount, 0, true)
+	require.NoError(t, err)
+	batchedResponse, err := searcher.SearchWithOptionsBatched(SearchOptions{
+		Ordered:      true,
+		SelectFields: []string{"title", "test"},
+	}, 5)
+	require.NoError(t, err)
+
+	var batchedResults []map[string]interface{}
+	err = json.Unmarshal([]byte(batchedResponse), &batchedResults)
+	require.NoError(t, err)
+	require.Len(t, batchedResults, docCount)
+	for _, result := range batchedResults {
+		doc := result["doc"].(map[string]interface{})
+		_, hasBody := doc["body"]
+		require.False(t, hasBody)
+		require.NotEmpty(t, doc["title"].([]interface{})[0].(string))
+	}
+	require.Greater(t, len(fullResponse), len(batchedResponse))
+	require.GreaterOrEqual(t, len(fullResponse)/len(batchedResponse), 8)
+}
+
+func benchmarkLargeSearchSetup(b *testing.B) *TSearcher {
+	b.Helper()
+	LibInit("error")
+	idx := makeLargeIndex(b, "", 96, 180)
+	rb, err := idx.ReaderBuilder()
+	require.NoError(b, err)
+	qp, err := rb.Searcher()
+	require.NoError(b, err)
+	_, err = qp.ForIndex([]string{"title", "body", "test"})
+	require.NoError(b, err)
+	searcher, err := qp.ParseQuery("body:payload")
+	require.NoError(b, err)
+	return searcher
+}
+
+func BenchmarkLargeSearchFull(b *testing.B) {
+	b.Setenv("LD_LIBRARY_PATH", ".")
+	searcher := benchmarkLargeSearchSetup(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		response, err := searcher.Search(false, 96, 0, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(response) == 0 {
+			b.Fatal("empty full search response")
+		}
+	}
+}
+
+func BenchmarkLargeSearchProjected(b *testing.B) {
+	b.Setenv("LD_LIBRARY_PATH", ".")
+	searcher := benchmarkLargeSearchSetup(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		response, err := searcher.SearchWithOptions(SearchOptions{
+			TopLimit:     96,
+			Ordered:      true,
+			SelectFields: []string{"title", "test"},
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(response) == 0 {
+			b.Fatal("empty projected search response")
+		}
+	}
+}
+
+func BenchmarkLargeSearchBatched(b *testing.B) {
+	b.Setenv("LD_LIBRARY_PATH", ".")
+	searcher := benchmarkLargeSearchSetup(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		response, err := searcher.SearchWithOptionsBatched(SearchOptions{
+			Ordered:      true,
+			SelectFields: []string{"title", "test"},
+		}, 16)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(response) == 0 {
+			b.Fatal("empty batched search response")
+		}
+	}
 }
 
 func TestStops(t *testing.T) {

--- a/src/tsession_searcher.rs
+++ b/src/tsession_searcher.rs
@@ -3,7 +3,6 @@ use crate::make_internal_json_error;
 use crate::ErrorKinds;
 use crate::InternalCallResult;
 use crate::TantivySession;
-use base64::Engine;
 use tantivy::DocAddress;
 use tantivy::Searcher;
 use tantivy::TERMINATED;
@@ -12,7 +11,6 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 use crate::HashMap;
-use base64::engine::general_purpose;
 use log::error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -182,6 +180,38 @@ pub struct ResultElementDoc {
 }
 
 impl TantivySession {
+    fn extract_string_array(params: &serde_json::Value, key: &str) -> Vec<String> {
+        params
+            .as_object()
+            .and_then(|p| p.get(key))
+            .and_then(|u| u.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.as_str().map(str::to_string))
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default()
+    }
+
+    fn project_named_doc(
+        &self,
+        named_doc: NamedFieldDocument,
+        select_fields: &[String],
+    ) -> NamedFieldDocument {
+        if select_fields.is_empty() {
+            return named_doc;
+        }
+
+        let mut projected = BTreeMap::<String, Vec<Value>>::new();
+        for field_name in select_fields {
+            if let Some(values) = named_doc.0.get(field_name) {
+                projected.insert(field_name.clone(), values.clone());
+            }
+        }
+
+        NamedFieldDocument(projected)
+    }
+
     pub fn handle_fuzzy_searcher(
         &mut self,
         method: &str,
@@ -303,6 +333,56 @@ impl TantivySession {
         }
     }
 
+    fn resolve_top_limit(searcher: &Searcher, top_limit: u64, offset: usize) -> u64 {
+        if top_limit == 0 {
+            searcher.num_docs().saturating_sub(offset as u64)
+        } else {
+            top_limit
+        }
+    }
+
+    fn build_result_element(
+        &self,
+        searcher: &Searcher,
+        query: &dyn Query,
+        doc_address: DocAddress,
+        score: f32,
+        explain: bool,
+        snippet_fields: &[String],
+        select_fields: &[String],
+    ) -> Result<ResultElement, ErrorKinds> {
+        let retrieved_doc = searcher.doc(doc_address)?;
+        let schema = self
+            .schema
+            .as_ref()
+            .ok_or_else(|| ErrorKinds::NotExist("Schema not present".to_string()))?;
+        let named_doc = self.project_named_doc(schema.to_named_doc(&retrieved_doc), select_fields);
+        let mut explanation = "noexplain".to_string();
+        if explain {
+            explanation = query.explain(searcher, doc_address)?.to_pretty_json();
+        }
+
+        let mut snippet_html: HashMap<String, String> = HashMap::new();
+        snippet_fields.iter().for_each(|field_name| {
+            if !field_name.is_empty() {
+                let snippet = match self.make_snippet(field_name, searcher, query, &retrieved_doc) {
+                    Ok(value) => (field_name.as_str(), value),
+                    Err(err) => ("", err.to_string()),
+                };
+                if !snippet.0.is_empty() {
+                    snippet_html.insert(snippet.0.to_string(), snippet.1);
+                }
+            }
+        });
+
+        Ok(ResultElement {
+            doc: named_doc,
+            score,
+            explain: explanation,
+            snippet_html: Some(snippet_html),
+        })
+    }
+
     fn do_docset(&mut self, params: serde_json::Value) -> InternalCallResult<u32> {
         const DEF_LIMIT: u64 = 10;
         let (top_limit, offset, score) = match params.as_object() {
@@ -316,6 +396,7 @@ impl TantivySession {
             None => (DEF_LIMIT, 0, true),
         };
         let (query, idx, searcher) = self.setup_searcher()?;
+        let top_limit = Self::resolve_top_limit(&searcher, top_limit, offset);
 
         let td = self.do_search_execute(&searcher, query, idx, offset, top_limit, score)?;
         debug!("search complete len = {}, td = {:?}", td.len(), td);
@@ -357,22 +438,16 @@ impl TantivySession {
     }
 
     fn do_get_document(&mut self, params: serde_json::Value) -> InternalCallResult<u32> {
-        let (segment_ord, doc_id, score, explain, fields) = match params.as_object() {
+        let snippet_fields = Self::extract_string_array(&params, "snippet_field");
+        let select_fields = Self::extract_string_array(&params, "select_fields");
+        let (segment_ord, doc_id, score, explain) = match params.as_object() {
             Some(p) => (
                 (p.get("segment_ord").and_then(|u| u.as_u64()).unwrap_or(0)) as u32,
                 (p.get("doc_id").and_then(|u| u.as_u64()).unwrap_or(0)) as u32,
                 (p.get("score").and_then(|u| u.as_f64()).unwrap_or(0.0)),
                 p.get("explain").and_then(|u| u.as_bool()).unwrap_or(false),
-                p.get("snippet_field")
-                    .and_then(|u| u.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|item| item.as_str())
-                            .collect::<Vec<&str>>()
-                    })
-                    .unwrap_or_else(Vec::new), // Default to an empty vector
             ),
-            None => (0, 0, 0.0, false, vec![]), // Default values
+            None => (0, 0, 0.0, false),
         };
 
         let doc_address = DocAddress {
@@ -381,45 +456,75 @@ impl TantivySession {
         };
         let (query, _idx, searcher) = self.setup_searcher()?;
 
-        let retrieved_doc = searcher.doc(doc_address)?;
-        let schema = self
-            .schema
-            .as_ref()
-            .ok_or_else(|| ErrorKinds::NotExist("Schema not present".to_string()))?;
-        let named_doc = schema.to_named_doc(&retrieved_doc);
-        let mut s: String = "noexplain".to_string();
-        if explain {
-            s = query.explain(&searcher, doc_address)?.to_pretty_json();
-        }
-        debug!("retrieved doc {:?}", retrieved_doc.field_values());
-
-        let mut hm: HashMap<String, String> = HashMap::new();
-
-        fields.iter().for_each(|&v| {
-            if !v.is_empty() {
-                let e = match self.make_snippet(v, &searcher, query, &retrieved_doc) {
-                    Ok(g) => (v, g),
-                    Err(e) => ("", e.to_string()),
-                };
-                if !e.0.is_empty() {
-                    hm.insert(e.0.to_string(), e.1);
-                }
-            }
-        });
-
-        let re = ResultElement {
-            doc: named_doc,
-            score: score as f32,
-            explain: s,
-            snippet_html: Some(hm),
-        };
+        let re = self.build_result_element(
+            &searcher,
+            query,
+            doc_address,
+            score as f32,
+            explain,
+            &snippet_fields,
+            &select_fields,
+        )?;
         self.return_buffer = serde_json::to_string(&re)?;
+        Ok(0)
+    }
+
+    fn do_get_documents(&mut self, params: serde_json::Value) -> InternalCallResult<u32> {
+        let snippet_fields = Self::extract_string_array(&params, "snippet_field");
+        let select_fields = Self::extract_string_array(&params, "select_fields");
+        let explain = params
+            .as_object()
+            .and_then(|p| p.get("explain"))
+            .and_then(|u| u.as_bool())
+            .unwrap_or(false);
+        let docs = params
+            .as_object()
+            .and_then(|p| p.get("docs"))
+            .and_then(|u| u.as_array())
+            .ok_or_else(|| ErrorKinds::BadParams("parameter 'docs' missing".to_string()))?;
+
+        let (query, _idx, searcher) = self.setup_searcher()?;
+        let mut results = Vec::<ResultElement>::with_capacity(docs.len());
+
+        for doc in docs {
+            let doc_obj = doc
+                .as_object()
+                .ok_or_else(|| ErrorKinds::BadParams("doc reference must be an object".to_string()))?;
+            let doc_address = DocAddress {
+                doc_id: doc_obj
+                    .get("doc_id")
+                    .and_then(|u| u.as_u64())
+                    .unwrap_or(0) as u32,
+                segment_ord: doc_obj
+                    .get("segment_ord")
+                    .and_then(|u| u.as_u64())
+                    .unwrap_or(0) as u32,
+            };
+            let score = doc_obj
+                .get("score")
+                .and_then(|u| u.as_f64())
+                .unwrap_or(0.0) as f32;
+
+            results.push(self.build_result_element(
+                &searcher,
+                query,
+                doc_address,
+                score,
+                explain,
+                &snippet_fields,
+                &select_fields,
+            )?);
+        }
+
+        self.return_buffer = serde_json::to_string(&results)?;
         Ok(0)
     }
 
     fn do_search(&mut self, params: serde_json::Value) -> InternalCallResult<u32> {
         const DEF_LIMIT: u64 = 10;
-        let (top_limit, offset, explain, score, fields) = match params.as_object() {
+        let snippet_fields = Self::extract_string_array(&params, "snippet_field");
+        let select_fields = Self::extract_string_array(&params, "select_fields");
+        let (top_limit, offset, explain, score) = match params.as_object() {
             Some(p) => (
                 p.get("top_limit")
                     .and_then(|u| u.as_u64())
@@ -427,58 +532,27 @@ impl TantivySession {
                 p.get("offset").and_then(|u| u.as_u64()).unwrap_or(0) as usize,
                 p.get("explain").and_then(|u| u.as_bool()).unwrap_or(false),
                 p.get("scoring").and_then(|u| u.as_bool()).unwrap_or(true),
-                p.get("snippet_field")
-                    .and_then(|u| u.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|item| item.as_str())
-                            .collect::<Vec<&str>>()
-                    })
-                    .unwrap_or_else(Vec::new), // Default to an empty vector
             ),
-            None => (DEF_LIMIT, 0, false, true, vec![]),
+            None => (DEF_LIMIT, 0, false, true),
         };
         let (query, idx, searcher) = self.setup_searcher()?;
+        let top_limit = Self::resolve_top_limit(&searcher, top_limit, offset);
 
         let td = self.do_search_execute(&searcher, query, idx, offset, top_limit, score)?;
-
-        let snippets = !fields.is_empty();
-
-        let mut hm = HashMap::new();
 
         debug!("search complete len = {}, td = {:?}", td.len(), td);
         let mut vret: Vec<ResultElement> = Vec::<ResultElement>::new();
         for (score, doc_address) in td {
-            let retrieved_doc = searcher.doc(doc_address)?;
-            let schema = self
-                .schema
-                .as_ref()
-                .ok_or_else(|| ErrorKinds::NotExist("Schema not present".to_string()))?;
-            let named_doc = schema.to_named_doc(&retrieved_doc);
-            let mut s: String = "noexplain".to_string();
-            if explain {
-                s = query.explain(&searcher, doc_address)?.to_pretty_json();
-            }
-            if snippets {
-                fields.iter().for_each(|&v| {
-                    if !v.is_empty() {
-                        let e = match self.make_snippet(v, &searcher, query, &retrieved_doc) {
-                            Ok(g) => (v, g),
-                            Err(e) => ("", e.to_string()),
-                        };
-                        if !e.0.is_empty() {
-                            hm.insert(e.0.to_string(), e.1);
-                        }
-                    }
-                });
-            }
-            debug!("retrieved doc {:?}", retrieved_doc.field_values());
-            vret.append(&mut vec![ResultElement {
-                doc: named_doc,
+            let result = self.build_result_element(
+                &searcher,
+                query,
+                doc_address,
                 score,
-                explain: s,
-                snippet_html: Some(hm.clone()),
-            }]);
+                explain,
+                &snippet_fields,
+                &select_fields,
+            )?;
+            vret.push(result);
         }
         self.return_buffer = serde_json::to_string(&vret)?;
         debug!("ret = {}", self.return_buffer);
@@ -552,13 +626,12 @@ impl TantivySession {
         params: serde_json::Value,
     ) -> InternalCallResult<u32> {
         debug!("Searcher");
-        let s = format!("{}", params);
-        println!("{}", s);
         match method {
             "search" => self.do_search(params),
             "search_raw" => self.do_raw_search(params),
             "docset" => self.do_docset(params),
             "get_document" => self.do_get_document(params),
+            "get_documents" => self.do_get_documents(params),
             _ => {
                 error!("unknown method {method}");
                 Err(ErrorKinds::NotExist(format!("unknown method {method}")))


### PR DESCRIPTION
## Problem

Vector search sync needs to query a very large Tantivy result set so the caller can apply permission filtering before pagination. The existing tantivy-jpc flow was fragile for this case for two reasons:

1. Large responses crossing the Go/Rust boundary could fail with `gobytes: length out of range`.
2. The normal search path returned fully hydrated documents in a single response, which becomes risky when the match set is large.

Pagination alone is not sufficient for this workflow because the full candidate set must be available before downstream filtering and paging can happen safely.

## Fix

This PR adds a safer large-result retrieval path and fixes the FFI boundary issue.

### FFI safety

The Go client now reads the Rust response length using the correct cgo-compatible type and validates it before converting the payload with `C.GoBytes`.

This removes the unsafe length handling that could panic on large responses.

### Projected-field retrieval

The Go and Rust search layers now support returning only selected fields instead of always hydrating the full stored document.

This reduces payload size significantly for workflows that only need a subset of fields.

### All-results docset flow

The searcher now supports retrieving all matching document references by treating `top_limit: 0` as “all matches” for docsets.

This allows the caller to collect the full candidate set as lightweight references first.

### Bulk document hydration

A new bulk retrieval path hydrates multiple document references in one call while still supporting field selection.

This supports the explicit two-step vector sync flow:

1. fetch all matching doc references
2. hydrate only the fields needed for downstream processing

### Batched large-result helper

A higher-level helper was added to handle the main large-result case automatically.

It fetches the full docset first, then hydrates selected fields in bounded batches and aggregates the final JSON response. This avoids oversized single-response transfers while preserving the full logical result set.

### Supporting updates

This branch also includes:

- large-result tests for projected and batched search
- vector-style tests for docset plus bulk hydration
- benchmarks comparing full, projected, and batched retrieval
- an example showing the vector sync access pattern
- README guidance for choosing the correct search path
- GitHub Actions updates for current runners and newer action versions

## Validation

Validation was done at multiple levels:

- existing Go tests continued to pass
- new large-result tests passed
- new vector-style bulk retrieval tests passed
- benchmarks for full, projected, and batched retrieval executed successfully
- the updated library was tested in fabric and passed there as well

The net result is that large Tantivy match sets can now be retrieved much more safely for vector sync without breaking the existing integration path.